### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ./gradlew build -x test
 FROM openjdk:8-jre-alpine
 COPY --from=builder /project/build/libs/*.jar /fms.jar
 RUN mkdir -p /var/log/openbaton
-RUN apk add -u --no-cache python3 python3-dev curl && pip3 install openbaton-cli==5.0.0rc1
+RUN apk add -u --no-cache python3 python3-dev curl && pip3 install --no-cache-dir openbaton-cli==5.0.0rc1
 COPY --from=builder /project/gradle/gradle/scripts/docker/fms.sh /fms.sh
 COPY --from=builder /project/src/main/resources/application.properties /etc/openbaton/openbaton-fms.properties
 ENTRYPOINT ["/fms.sh"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>